### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - run: flutter pub get
 
-      - run: flutter pub run build_runner build --delete-conflicting-outputs
+      - run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Build Project
         run: flutter build ${{ matrix.pkg }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install [Flutter](https://flutter.dev/) and all of its requirements for the plat
 
 ```bash
 flutter pub get
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 flutter build <windows/linux/apk etc>
 ```
 

--- a/lib/drawer.dart
+++ b/lib/drawer.dart
@@ -12,104 +12,102 @@ class MainDrawer extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final index = ref.watch(homepageProvider);
     const appicon = CircleAvatar(
       foregroundImage: AssetImage('assets/icon.png'),
     );
 
-    return Drawer(
-      child: ListView(
-        padding: EdgeInsets.zero,
-        children: [
-          DrawerHeader(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.primaryContainer,
+    return NavigationDrawer(
+      onDestinationSelected: (index) {
+        ref.read(homepageProvider.notifier).state =
+            HomePage.values.elementAt(index);
+      },
+      selectedIndex: index.index,
+      children: [
+        DrawerHeader(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primaryContainer,
+          ),
+          child: const Center(
+            child: Column(
+              children: [appicon, Text('Gagaku')],
             ),
-            child: const Center(
-              child: Column(
-                children: [appicon, Text('Gagaku')],
-              ),
-            ),
           ),
-          ListTile(
-            leading: const Icon(Icons.menu_book),
-            title: const Text('MangaDex'),
-            onTap: () {
-              ref.read(homepageProvider.notifier).state = HomePage.mangadex;
-            },
-          ),
-          ListTile(
-            leading: const Icon(Icons.photo_album),
-            title: const Text('Local Library'),
-            onTap: () {
-              ref.read(homepageProvider.notifier).state = HomePage.local;
-            },
-          ),
-          ListTile(
-            leading: const Icon(Icons.language),
-            title: const Text('Web Sources'),
-            onTap: () {
-              ref.read(homepageProvider.notifier).state = HomePage.web;
-            },
-          ),
-          FutureBuilder(
-            future: PackageInfo.fromPlatform(),
-            builder: (context, snapshot) {
-              if (snapshot.hasData) {
-                return AboutListTile(
-                  icon: const Icon(Icons.info),
-                  applicationIcon: appicon,
-                  applicationName: snapshot.data!.appName,
-                  applicationVersion: snapshot.data!.version,
-                  applicationLegalese: '\u{a9} 2023 r52',
-                  aboutBoxChildren: [
-                    const SizedBox(
-                      height: 4,
+        ),
+        const NavigationDrawerDestination(
+          icon: Icon(Icons.menu_book_outlined),
+          selectedIcon: Icon(Icons.menu_book),
+          label: Text('MangaDex'),
+        ),
+        const NavigationDrawerDestination(
+          icon: Icon(Icons.photo_album_outlined),
+          selectedIcon: Icon(Icons.photo_album),
+          label: Text('Local Library'),
+        ),
+        const NavigationDrawerDestination(
+          icon: Icon(Icons.language_outlined),
+          selectedIcon: Icon(Icons.language),
+          label: Text('Web Sources'),
+        ),
+        const Divider(),
+        FutureBuilder(
+          future: PackageInfo.fromPlatform(),
+          builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              return AboutListTile(
+                icon: const Icon(Icons.info),
+                applicationIcon: appicon,
+                applicationName: snapshot.data!.appName,
+                applicationVersion: snapshot.data!.version,
+                applicationLegalese: '\u{a9} 2023 r52',
+                aboutBoxChildren: [
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  const Text('Flutter: $kFlutterFrameworkVersion'),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  const Text('Dart: $kFlutterDartSdkVersion'),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  const Text('Built on: $kBuildTimestamp'),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  const Text('License: MIT'),
+                  const SizedBox(
+                    height: 4,
+                  ),
+                  RichText(
+                    text: TextSpan(
+                      children: <TextSpan>[
+                        const TextSpan(text: 'Source code available at '),
+                        TextSpan(
+                          style: const TextStyle(color: Colors.blue),
+                          text: 'GitHub',
+                          recognizer: TapGestureRecognizer()
+                            ..onTap = () {
+                              launchUrl(
+                                  Uri.parse('https://github.com/r52/gagaku'));
+                            },
+                        ),
+                        const TextSpan(text: '.'),
+                      ],
                     ),
-                    const Text('Flutter: $kFlutterFrameworkVersion'),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    const Text('Dart: $kFlutterDartSdkVersion'),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    const Text('Built on: $kBuildTimestamp'),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    const Text('License: MIT'),
-                    const SizedBox(
-                      height: 4,
-                    ),
-                    RichText(
-                      text: TextSpan(
-                        children: <TextSpan>[
-                          const TextSpan(text: 'Source code available at '),
-                          TextSpan(
-                            style: const TextStyle(color: Colors.blue),
-                            text: 'GitHub',
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                launchUrl(
-                                    Uri.parse('https://github.com/r52/gagaku'));
-                              },
-                          ),
-                          const TextSpan(text: '.'),
-                        ],
-                      ),
-                    ),
-                  ],
-                );
-              }
-
-              return const ListTile(
-                leading: Icon(Icons.info),
-                title: Text('About gagaku'),
+                  ),
+                ],
               );
-            },
-          ),
-        ],
-      ),
+            }
+
+            return const ListTile(
+              leading: Icon(Icons.info),
+              title: Text('About gagaku'),
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/local/archive_reader.dart
+++ b/lib/local/archive_reader.dart
@@ -106,7 +106,8 @@ class ArchiveReaderWidget extends ConsumerWidget {
       case AsyncValue(:final error?, :final stackTrace?):
         final messenger = ScaffoldMessenger.of(context);
         Styles.showErrorSnackBar(messenger, '$error');
-        logger.e("_getArchivePagesProvider($path) failed", error, stackTrace);
+        logger.e("_getArchivePagesProvider($path) failed",
+            error: error, stackTrace: stackTrace);
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/local/archive_reader.g.dart
+++ b/lib/local/archive_reader.g.dart
@@ -110,4 +110,5 @@ class _GetArchivePagesProvider
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/local/config.g.dart
+++ b/lib/local/config.g.dart
@@ -35,4 +35,5 @@ final localConfigProvider =
 );
 
 typedef _$LocalConfig = Notifier<LocalLibConfig>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/local/directory_reader.dart
+++ b/lib/local/directory_reader.dart
@@ -79,7 +79,8 @@ class DirectoryReaderWidget extends ConsumerWidget {
       case AsyncValue(:final error?, :final stackTrace?):
         final messenger = ScaffoldMessenger.of(context);
         Styles.showErrorSnackBar(messenger, '$error');
-        logger.e("_getDirectoryPagesProvider($path) failed", error, stackTrace);
+        logger.e("_getDirectoryPagesProvider($path) failed",
+            error: error, stackTrace: stackTrace);
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/local/directory_reader.g.dart
+++ b/lib/local/directory_reader.g.dart
@@ -110,4 +110,5 @@ class _GetDirectoryPagesProvider
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/local/main.dart
+++ b/lib/local/main.dart
@@ -186,7 +186,8 @@ class LocalLibraryHome extends HookConsumerWidget {
           case AsyncError(:final error, :final stackTrace):
             final messenger = ScaffoldMessenger.of(context);
             Styles.showErrorSnackBar(messenger, '$error');
-            logger.e("localLibraryProvider failed", error, stackTrace);
+            logger.e("localLibraryProvider failed",
+                error: error, stackTrace: stackTrace);
 
             return RefreshIndicator(
               onRefresh: () async {

--- a/lib/local/model.g.dart
+++ b/lib/local/model.g.dart
@@ -21,4 +21,5 @@ final localLibraryProvider =
 );
 
 typedef _$LocalLibrary = AsyncNotifier<LocalLibraryItem>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/chapter_feed.g.dart
+++ b/lib/mangadex/chapter_feed.g.dart
@@ -23,4 +23,5 @@ final _fetchChaptersProvider =
 
 typedef _FetchChaptersRef
     = AutoDisposeFutureProviderRef<List<ChapterFeedItemData>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/config.g.dart
+++ b/lib/mangadex/config.g.dart
@@ -67,4 +67,5 @@ final mdConfigProvider =
 );
 
 typedef _$MdConfig = AutoDisposeNotifier<MangaDexConfig>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/creator_view.dart
+++ b/lib/mangadex/creator_view.dart
@@ -63,8 +63,8 @@ class MangaDexCreatorViewWidget extends HookConsumerWidget {
           AsyncValue(:final error?, :final stackTrace?) => () {
               final messenger = ScaffoldMessenger.of(context);
               Styles.showErrorSnackBar(messenger, '$error');
-              logger.e("_fetchCreatorTitlesProvider(creator) failed", error,
-                  stackTrace);
+              logger.e("_fetchCreatorTitlesProvider(creator) failed",
+                  error: error, stackTrace: stackTrace);
 
               return RefreshIndicator(
                 onRefresh: () async {

--- a/lib/mangadex/creator_view.g.dart
+++ b/lib/mangadex/creator_view.g.dart
@@ -111,4 +111,5 @@ class _FetchCreatorTitlesProvider
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/group_view.dart
+++ b/lib/mangadex/group_view.dart
@@ -202,8 +202,8 @@ class MangaDexGroupViewWidget extends HookWidget {
                 AsyncValue(:final error?, :final stackTrace?) => () {
                     final messenger = ScaffoldMessenger.of(context);
                     Styles.showErrorSnackBar(messenger, '$error');
-                    logger.e("_fetchGroupTitlesProvider(group) failed", error,
-                        stackTrace);
+                    logger.e("_fetchGroupTitlesProvider(group) failed",
+                        error: error, stackTrace: stackTrace);
 
                     return RefreshIndicator(
                       onRefresh: () async {

--- a/lib/mangadex/group_view.g.dart
+++ b/lib/mangadex/group_view.g.dart
@@ -195,4 +195,5 @@ class _FetchGroupTitlesProvider
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/history_feed.g.dart
+++ b/lib/mangadex/history_feed.g.dart
@@ -23,4 +23,5 @@ final _fetchHistoryFeedProvider =
 
 typedef _FetchHistoryFeedRef
     = AutoDisposeFutureProviderRef<List<ChapterFeedItemData>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/latest_feed.g.dart
+++ b/lib/mangadex/latest_feed.g.dart
@@ -24,4 +24,5 @@ final _fetchGlobalChaptersProvider =
 
 typedef _FetchGlobalChaptersRef
     = AutoDisposeFutureProviderRef<List<ChapterFeedItemData>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/library.dart
+++ b/lib/mangadex/library.dart
@@ -60,8 +60,8 @@ class MangaDexLibraryView extends ConsumerWidget {
                     AsyncValue(:final error?, :final stackTrace?) => () {
                         final messenger = ScaffoldMessenger.of(context);
                         Styles.showErrorSnackBar(messenger, '$error');
-                        logger.e("userLibraryProvider($type) failed", error,
-                            stackTrace);
+                        logger.e("userLibraryProvider($type) failed",
+                            error: error, stackTrace: stackTrace);
 
                         return Styles.errorColumn(error, stackTrace);
                       }(),

--- a/lib/mangadex/login_oauth.dart
+++ b/lib/mangadex/login_oauth.dart
@@ -30,7 +30,8 @@ class MangaDexLoginWidget extends ConsumerWidget {
           ),
         );
       case AsyncError(:final error, :final stackTrace):
-        logger.e("authControlProvider failed", error, stackTrace);
+        logger.e("authControlProvider failed",
+            error: error, stackTrace: stackTrace);
         return Styles.errorColumn(error, stackTrace);
       case _:
         return const Center(

--- a/lib/mangadex/login_old.dart
+++ b/lib/mangadex/login_old.dart
@@ -37,7 +37,8 @@ class MangaDexLoginWidget extends ConsumerWidget {
           ),
         );
       case AsyncError(:final error, :final stackTrace):
-        logger.e("authControlProvider failed", error, stackTrace);
+        logger.e("authControlProvider failed",
+            error: error, stackTrace: stackTrace);
         return Styles.errorColumn(error, stackTrace);
       case _:
         return const Center(

--- a/lib/mangadex/main.dart
+++ b/lib/mangadex/main.dart
@@ -33,6 +33,14 @@ class MangaDexHome extends HookConsumerWidget {
     final nav = Navigator.of(context);
     final theme = Theme.of(context);
     final tab = ref.watch(_mangadexTabProvider);
+    final lifecycle = useAppLifecycleState();
+
+    useEffect(() {
+      if (lifecycle == AppLifecycleState.resumed) {
+        ref.read(authControlProvider.notifier).invalidate();
+      }
+      return null;
+    }, [lifecycle]);
 
     const bottomNavigationBarItems = <BottomNavigationBarItem>[
       BottomNavigationBarItem(

--- a/lib/mangadex/main.dart
+++ b/lib/mangadex/main.dart
@@ -42,24 +42,24 @@ class MangaDexHome extends HookConsumerWidget {
       return null;
     }, [lifecycle]);
 
-    const bottomNavigationBarItems = <BottomNavigationBarItem>[
-      BottomNavigationBarItem(
+    const bottomNavigationBarItems = <Widget>[
+      NavigationDestination(
         icon: Icon(Icons.home),
         label: 'Latest Feed',
       ),
-      BottomNavigationBarItem(
+      NavigationDestination(
         icon: Icon(Icons.menu_book),
         label: 'Manga Feed',
       ),
-      BottomNavigationBarItem(
+      NavigationDestination(
         icon: Icon(Icons.feed),
         label: 'Chapter Feed',
       ),
-      BottomNavigationBarItem(
+      NavigationDestination(
         icon: Icon(Icons.collections),
         label: 'Library',
       ),
-      BottomNavigationBarItem(
+      NavigationDestination(
         icon: Icon(Icons.history),
         label: 'Reading History',
       )
@@ -78,6 +78,7 @@ class MangaDexHome extends HookConsumerWidget {
         controller: controllers[0],
       ),
       MangaDexLoginWidget(
+        key: const Key('mangafeed'),
         builder: (context, ref) {
           return MangaDexMangaFeed(
             controller: controllers[1],
@@ -85,6 +86,7 @@ class MangaDexHome extends HookConsumerWidget {
         },
       ),
       MangaDexLoginWidget(
+        key: const Key('chapterfeed'),
         builder: (context, ref) {
           return MangaDexChapterFeed(
             controller: controllers[2],
@@ -92,6 +94,7 @@ class MangaDexHome extends HookConsumerWidget {
         },
       ),
       MangaDexLoginWidget(
+        key: const Key('userlibrary'),
         builder: (context, ref) {
           return MangaDexLibraryView(
             controller: controllers[3],
@@ -225,13 +228,12 @@ class MangaDexHome extends HookConsumerWidget {
           child: tabs[tab.index],
         ),
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        showUnselectedLabels: false,
-        items: bottomNavigationBarItems,
-        currentIndex: tab.index,
-        type: BottomNavigationBarType.fixed,
-        selectedItemColor: theme.colorScheme.primary,
-        onTap: (index) {
+      bottomNavigationBar: NavigationBar(
+        height: 60,
+        labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
+        destinations: bottomNavigationBarItems,
+        selectedIndex: tab.index,
+        onDestinationSelected: (index) {
           final currTab = ref.read(_mangadexTabProvider);
 
           if (currTab == MangaDexTab.values[index]) {

--- a/lib/mangadex/main.dart
+++ b/lib/mangadex/main.dart
@@ -189,7 +189,8 @@ class MangaDexHome extends HookConsumerWidget {
                     case AsyncError(:final error, :final stackTrace):
                       final messenger = ScaffoldMessenger.of(context);
                       Styles.showErrorSnackBar(messenger, '$error');
-                      logger.e("authControlProvider failed", error, stackTrace);
+                      logger.e("authControlProvider failed",
+                          error: error, stackTrace: stackTrace);
                       return const Icon(Icons.error);
                     case _:
                       return const Center(

--- a/lib/mangadex/manga_feed.dart
+++ b/lib/mangadex/manga_feed.dart
@@ -46,7 +46,8 @@ class MangaDexMangaFeed extends ConsumerWidget {
             AsyncValue(:final error?, :final stackTrace?) => () {
                 final messenger = ScaffoldMessenger.of(context);
                 Styles.showErrorSnackBar(messenger, '$error');
-                logger.e("_fetchMangaFeedProvider failed", error, stackTrace);
+                logger.e("_fetchMangaFeedProvider failed",
+                    error: error, stackTrace: stackTrace);
 
                 return RefreshIndicator(
                   onRefresh: () async {

--- a/lib/mangadex/manga_feed.g.dart
+++ b/lib/mangadex/manga_feed.g.dart
@@ -22,4 +22,5 @@ final _fetchMangaFeedProvider =
 );
 
 typedef _FetchMangaFeedRef = AutoDisposeFutureProviderRef<Iterable<Manga>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/manga_view.dart
+++ b/lib/mangadex/manga_view.dart
@@ -65,7 +65,8 @@ class MangaDexMangaViewWidget extends HookConsumerWidget {
         AsyncValue(:final error?, :final stackTrace?) => () {
             final messenger = ScaffoldMessenger.of(context);
             Styles.showErrorSnackBar(messenger, '$error');
-            logger.e("readChaptersProvider failed", error, stackTrace);
+            logger.e("readChaptersProvider failed",
+                error: error, stackTrace: stackTrace);
 
             return null;
           }(),
@@ -806,8 +807,8 @@ class MangaDexMangaViewWidget extends HookConsumerWidget {
                 AsyncValue(:final error?, :final stackTrace?) => () {
                     final messenger = ScaffoldMessenger.of(context);
                     Styles.showErrorSnackBar(messenger, '$error');
-                    logger.e("mangaChaptersProvider(${manga.id}) failed", error,
-                        stackTrace);
+                    logger.e("mangaChaptersProvider(${manga.id}) failed",
+                        error: error, stackTrace: stackTrace);
 
                     return SliverToBoxAdapter(
                       child: Styles.errorColumn(error, stackTrace),
@@ -906,8 +907,8 @@ class MangaDexMangaViewWidget extends HookConsumerWidget {
                 AsyncValue(:final error?, :final stackTrace?) => () {
                     final messenger = ScaffoldMessenger.of(context);
                     Styles.showErrorSnackBar(messenger, '$error');
-                    logger.e("mangaCoversProvider(${manga.id}) failed", error,
-                        stackTrace);
+                    logger.e("mangaCoversProvider(${manga.id}) failed",
+                        error: error, stackTrace: stackTrace);
 
                     return SliverToBoxAdapter(
                       child: Styles.errorColumn(error, stackTrace),

--- a/lib/mangadex/manga_view.dart
+++ b/lib/mangadex/manga_view.dart
@@ -1037,7 +1037,7 @@ class _CoverArtItem extends StatelessWidget {
         child: InkWell(
           onTap: onTap,
           child: GridTile(
-            footer: cover.attributes.volume != null
+            footer: cover.attributes?.volume != null
                 ? SizedBox(
                     height: 40,
                     child: Material(
@@ -1050,7 +1050,7 @@ class _CoverArtItem extends StatelessWidget {
                       child: GridTileBar(
                         backgroundColor: Colors.black45,
                         title: Text(
-                          'Volume ${cover.attributes.volume!}',
+                          'Volume ${cover.attributes!.volume!}',
                           softWrap: true,
                           style: const TextStyle(
                             overflow: TextOverflow.fade,

--- a/lib/mangadex/manga_view.g.dart
+++ b/lib/mangadex/manga_view.g.dart
@@ -110,4 +110,5 @@ class _FetchReadChaptersRedunProvider extends AutoDisposeFutureProvider<void> {
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/model.dart
+++ b/lib/mangadex/model.dart
@@ -2116,6 +2116,12 @@ class MangaDexHistory extends _$MangaDexHistory {
 class AuthControl extends _$AuthControl {
   Timer? _staleTime;
 
+  Future<void> invalidate() async {
+    state = await AsyncValue.guard(() async {
+      return await _build();
+    });
+  }
+
   Future<void> _setStaleTime() async {
     final api = ref.watch(mangadexProvider);
 
@@ -2138,8 +2144,7 @@ class AuthControl extends _$AuthControl {
     });
   }
 
-  @override
-  FutureOr<bool> build() async {
+  Future<bool> _build() async {
     final api = ref.watch(mangadexProvider);
     await api.future;
 
@@ -2151,6 +2156,11 @@ class AuthControl extends _$AuthControl {
     await _setStaleTime();
 
     return await api.loggedIn();
+  }
+
+  @override
+  FutureOr<bool> build() async {
+    return await _build();
   }
 
   Future<bool> login(String user, String pass) async {

--- a/lib/mangadex/model.dart
+++ b/lib/mangadex/model.dart
@@ -222,7 +222,7 @@ class MangaDexModel {
           }
 
           logger.w("refreshToken() returned code ${response.statusCode}",
-              response.body);
+              error: response.body);
         }
       }
 
@@ -282,8 +282,8 @@ class MangaDexModel {
       }
     }
 
-    logger.w(
-        "authenticate() returned code ${response.statusCode}", response.body);
+    logger.w("authenticate() returned code ${response.statusCode}",
+        error: response.body);
   }
 
   // Future<void> _saveToken(TokenResponse token) async {
@@ -333,7 +333,8 @@ class MangaDexModel {
         }
       }
 
-      logger.w("logout() returned code ${response.statusCode}", response.body);
+      logger.w("logout() returned code ${response.statusCode}",
+          error: response.body);
     }
   }
 
@@ -396,7 +397,7 @@ class MangaDexModel {
 
     // Throw if failure
     final msg = "fetchUserFeed() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -455,7 +456,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "fetchChapterFeed() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -500,7 +501,7 @@ class MangaDexModel {
           // Throw if failure
           final msg =
               "fetchChapters() failed. Response code: ${response.statusCode}";
-          logger.e(msg, response.body);
+          logger.e(msg, error: response.body);
           throw Exception(msg);
         }
       }
@@ -558,7 +559,7 @@ class MangaDexModel {
             // Throw if failure
             final msg =
                 "fetchManga(ids) failed. Response code: ${response.statusCode}";
-            logger.e(msg, response.body);
+            logger.e(msg, error: response.body);
             throw Exception(msg);
           }
         }
@@ -604,7 +605,7 @@ class MangaDexModel {
         // Throw if failure
         final msg =
             "fetchManga(filterId) failed. Response code: ${response.statusCode}";
-        logger.e(msg, response.body);
+        logger.e(msg, error: response.body);
         throw Exception(msg);
       }
     }
@@ -662,7 +663,7 @@ class MangaDexModel {
 
     // Throw if failure
     final msg = "searchManga() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -689,7 +690,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "getMangaFollowing() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -719,7 +720,7 @@ class MangaDexModel {
     // Log the failure
     logger.w(
         "setMangaFollowing(${manga.id}, $setFollow) returned code ${response.statusCode}",
-        response.body);
+        error: response.body);
 
     return false;
   }
@@ -755,7 +756,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "getMangaReadingStatus() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -791,7 +792,7 @@ class MangaDexModel {
     // Log the failure
     logger.w(
         "setMangaReadingStatus(${manga.id}, $status) returned code ${response.statusCode}",
-        response.body);
+        error: response.body);
 
     return false;
   }
@@ -841,7 +842,7 @@ class MangaDexModel {
         // Throw if failure
         final msg =
             "fetchReadChapters() failed. Response code: ${response.statusCode}";
-        logger.e(msg, response.body);
+        logger.e(msg, error: response.body);
         throw Exception(msg);
       }
     }
@@ -897,7 +898,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "fetchMangaChapters() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -932,7 +933,7 @@ class MangaDexModel {
     // Log the failure
     logger.w(
         "setChaptersRead(${manga.id}, ${chapters.toString()}, $setRead) returned code ${response.statusCode}",
-        response.body);
+        error: response.body);
 
     return false;
   }
@@ -972,7 +973,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "getChapterServer() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -1012,7 +1013,7 @@ class MangaDexModel {
     // Throw if failure
     final msg =
         "fetchUserLibrary() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -1040,7 +1041,7 @@ class MangaDexModel {
 
     // Throw if failure
     final msg = "getTagList() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -1070,7 +1071,7 @@ class MangaDexModel {
         // Throw if failure
         final msg =
             "fetchStatistics() failed. Response code: ${response.statusCode}";
-        logger.e(msg, response.body);
+        logger.e(msg, error: response.body);
         throw Exception(msg);
       }
     }
@@ -1102,7 +1103,7 @@ class MangaDexModel {
 
     // Throw if failure
     final msg = "getCoverList() failed. Response code: ${response.statusCode}";
-    logger.e(msg, response.body);
+    logger.e(msg, error: response.body);
     throw Exception(msg);
   }
 
@@ -1131,7 +1132,7 @@ class MangaDexModel {
         // Throw if failure
         final msg =
             "fetchRating() failed. Response code: ${response.statusCode}";
-        logger.e(msg, response.body);
+        logger.e(msg, error: response.body);
         throw Exception(msg);
       }
     }
@@ -1174,7 +1175,7 @@ class MangaDexModel {
     // Log the failure
     logger.w(
         "setMangaRating(${manga.id}, $rating) returned code ${response.statusCode}",
-        response.body);
+        error: response.body);
 
     return false;
   }

--- a/lib/mangadex/model.dart
+++ b/lib/mangadex/model.dart
@@ -91,7 +91,10 @@ abstract class CacheLists {
   static const tags = 'tags';
 }
 
-final mangadexProvider = Provider(MangaDexModel.new);
+@Riverpod(keepAlive: true)
+MangaDexModel mangadex(MangadexRef ref) {
+  return MangaDexModel(ref);
+}
 
 class MangaDexModel {
   MangaDexModel(this.ref) {

--- a/lib/mangadex/model.g.dart
+++ b/lib/mangadex/model.g.dart
@@ -6,6 +6,20 @@ part of 'model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$mangadexHash() => r'a292b576f657f3f4f75a624bdf14e965c33f39fe';
+
+/// See also [mangadex].
+@ProviderFor(mangadex)
+final mangadexProvider = Provider<MangaDexModel>.internal(
+  mangadex,
+  name: r'mangadexProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$mangadexHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef MangadexRef = ProviderRef<MangaDexModel>;
 String _$latestChaptersFeedHash() =>
     r'ea75ba36369bdde3c5c2eb72f6c98bd779ded249';
 

--- a/lib/mangadex/model.g.dart
+++ b/lib/mangadex/model.g.dart
@@ -553,12 +553,12 @@ class MangaCoversProvider
   }
 }
 
-String _$readChaptersHash() => r'a98afd37a00836974a53b24ce85f68a96fddf96b';
+String _$readChaptersHash() => r'429f19ab4f255aee8b5e414fd754ac8621091dc2';
 
 /// See also [ReadChapters].
 @ProviderFor(ReadChapters)
 final readChaptersProvider =
-    AsyncNotifierProvider<ReadChapters, Map<String, Set<String>>>.internal(
+    AsyncNotifierProvider<ReadChapters, Map<String, ReadChapterSet>>.internal(
   ReadChapters.new,
   name: r'readChaptersProvider',
   debugGetCreateSourceHash:
@@ -567,7 +567,7 @@ final readChaptersProvider =
   allTransitiveDependencies: null,
 );
 
-typedef _$ReadChapters = AsyncNotifier<Map<String, Set<String>>>;
+typedef _$ReadChapters = AsyncNotifier<Map<String, ReadChapterSet>>;
 String _$userLibraryHash() => r'db728effebe55f58d3dd147c3727b6fdf3db8f09';
 
 abstract class _$UserLibrary extends BuildlessAsyncNotifier<Iterable<Manga>> {
@@ -790,7 +790,7 @@ final statisticsProvider =
 );
 
 typedef _$Statistics = AsyncNotifier<Map<String, MangaStatistics>>;
-String _$ratingsHash() => r'f507d7d7f9d27c0ff7f572a6a24d281b80794fef';
+String _$ratingsHash() => r'd5689480a48de244cd7961f14e225e23811e08b9';
 
 /// See also [Ratings].
 @ProviderFor(Ratings)
@@ -805,7 +805,7 @@ final ratingsProvider =
 );
 
 typedef _$Ratings = AsyncNotifier<Map<String, SelfRating>>;
-String _$readingStatusHash() => r'5281cee334576d80177ad0c9b441badde919ffd6';
+String _$readingStatusHash() => r'c6928956665b33e7a7559ae2ba0d669ab8a2a577';
 
 abstract class _$ReadingStatus
     extends BuildlessAsyncNotifier<MangaReadingStatus?> {
@@ -902,7 +902,7 @@ class ReadingStatusProvider
   }
 }
 
-String _$followingStatusHash() => r'd4a6e4ee1ab4525be4dd02a3fd77277c084bc941';
+String _$followingStatusHash() => r'fb96192a8468fb7dacb102b3b253c4235cd4c1cc';
 
 abstract class _$FollowingStatus extends BuildlessAsyncNotifier<bool> {
   late final Manga manga;
@@ -1014,7 +1014,7 @@ final mangaDexHistoryProvider =
 );
 
 typedef _$MangaDexHistory = AsyncNotifier<Queue<Chapter>>;
-String _$authControlHash() => r'3369161c63949d7aade0b5ff8102e5603069df11';
+String _$authControlHash() => r'f25650165fcc9db88651cdc07f10b82d4d315cce';
 
 /// See also [AuthControl].
 @ProviderFor(AuthControl)

--- a/lib/mangadex/model.g.dart
+++ b/lib/mangadex/model.g.dart
@@ -1029,4 +1029,5 @@ final authControlProvider =
 );
 
 typedef _$AuthControl = AutoDisposeAsyncNotifier<bool>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/model.g.dart
+++ b/lib/mangadex/model.g.dart
@@ -1014,7 +1014,7 @@ final mangaDexHistoryProvider =
 );
 
 typedef _$MangaDexHistory = AsyncNotifier<Queue<Chapter>>;
-String _$authControlHash() => r'2a64d9dd0973ac8902ec2e89438b2834f825327f';
+String _$authControlHash() => r'3369161c63949d7aade0b5ff8102e5603069df11';
 
 /// See also [AuthControl].
 @ProviderFor(AuthControl)

--- a/lib/mangadex/model.g.dart
+++ b/lib/mangadex/model.g.dart
@@ -568,7 +568,7 @@ final readChaptersProvider =
 );
 
 typedef _$ReadChapters = AsyncNotifier<Map<String, Set<String>>>;
-String _$userLibraryHash() => r'b057b553aa3ffd5b01d113266a518d7f55dad8ac';
+String _$userLibraryHash() => r'db728effebe55f58d3dd147c3727b6fdf3db8f09';
 
 abstract class _$UserLibrary extends BuildlessAsyncNotifier<Iterable<Manga>> {
   late final MangaReadingStatus status;

--- a/lib/mangadex/reader.dart
+++ b/lib/mangadex/reader.dart
@@ -88,8 +88,8 @@ class MangaDexReaderWidget extends HookConsumerWidget {
       case AsyncValue(:final error?, :final stackTrace?):
         final messenger = ScaffoldMessenger.of(context);
         Styles.showErrorSnackBar(messenger, '$error');
-        logger.e("_fetchChapterPagesProvider(${chapter.id}) failed", error,
-            stackTrace);
+        logger.e("_fetchChapterPagesProvider(${chapter.id}) failed",
+            error: error, stackTrace: stackTrace);
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/mangadex/reader.g.dart
+++ b/lib/mangadex/reader.g.dart
@@ -110,4 +110,5 @@ class _FetchChapterPagesProvider
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/mangadex/search.dart
+++ b/lib/mangadex/search.dart
@@ -133,8 +133,8 @@ class MangaDexSearchWidget extends HookConsumerWidget {
               AsyncValue(:final error?, :final stackTrace?) => () {
                   final messenger = ScaffoldMessenger.of(context);
                   Styles.showErrorSnackBar(messenger, '$error');
-                  logger.e(
-                      "mangaSearchProvider(filter) failed", error, stackTrace);
+                  logger.e("mangaSearchProvider(filter) failed",
+                      error: error, stackTrace: stackTrace);
 
                   return SliverToBoxAdapter(
                     child: Styles.errorColumn(error, stackTrace),
@@ -492,7 +492,8 @@ class _MangaDexFilterWidget extends HookConsumerWidget {
         AsyncError(:final error, :final stackTrace) => () {
             final messenger = ScaffoldMessenger.of(context);
             Styles.showErrorSnackBar(messenger, '$error');
-            logger.e("tagListProvider failed", error, stackTrace);
+            logger.e("tagListProvider failed",
+                error: error, stackTrace: stackTrace);
 
             return Styles.errorColumn(error, stackTrace);
           }(),

--- a/lib/mangadex/search.dart
+++ b/lib/mangadex/search.dart
@@ -92,6 +92,7 @@ class MangaDexSearchWidget extends HookConsumerWidget {
                   children: [
                     Expanded(
                       child: TextField(
+                        textInputAction: TextInputAction.search,
                         autofocus: true,
                         controller: controller,
                         onChanged: onSearchChanged,

--- a/lib/mangadex/types.dart
+++ b/lib/mangadex/types.dart
@@ -460,7 +460,7 @@ abstract class Group with MangaDexUUID {
 }
 
 abstract class Cover with MangaDexUUID {
-  CoverArtAttributes get attributes;
+  CoverArtAttributes? get attributes;
 }
 
 abstract class CreatorType with MangaDexUUID {
@@ -500,7 +500,7 @@ class Relationship with _$Relationship, MangaDexUUID {
   @Implements<Cover>()
   const factory Relationship.cover({
     required String id,
-    required CoverArtAttributes attributes,
+    required CoverArtAttributes? attributes,
   }) = CoverArt;
 
   @FreezedUnionValue('scanlation_group')
@@ -610,7 +610,7 @@ class Manga with _$Manga, MangaDexUUID {
 
   String getFirstCoverUrl({CoverArtQuality quality = CoverArtQuality.best}) {
     if (covers.isEmpty) {
-      return 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/No-Image-Placeholder.svg/624px-No-Image-Placeholder.svg.png';
+      return 'https://mangadex.org/img/cover-placeholder.jpg';
     }
 
     return covers.first.quality(quality: quality);
@@ -618,7 +618,11 @@ class Manga with _$Manga, MangaDexUUID {
 
   CoverArtUrl getUrlFromCover(Cover cover,
       {CoverArtQuality quality = CoverArtQuality.best}) {
-    final filename = cover.attributes.fileName;
+    final filename = cover.attributes?.fileName;
+
+    if (filename == null) {
+      return 'https://mangadex.org/img/cover-placeholder.jpg';
+    }
 
     return 'https://uploads.mangadex.org/covers/$id/$filename'
         .quality(quality: quality);

--- a/lib/mangadex/types.freezed.dart
+++ b/lib/mangadex/types.freezed.dart
@@ -2296,7 +2296,7 @@ mixin _$Relationship {
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) =>
@@ -2308,7 +2308,7 @@ mixin _$Relationship {
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) =>
       throw _privateConstructorUsedError;
@@ -2319,7 +2319,7 @@ mixin _$Relationship {
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) =>
@@ -2474,7 +2474,7 @@ class _$RelationshipManga
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -2489,7 +2489,7 @@ class _$RelationshipManga
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return manga?.call(id);
@@ -2503,7 +2503,7 @@ class _$RelationshipManga
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -2678,7 +2678,7 @@ class _$RelationshipUser
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -2693,7 +2693,7 @@ class _$RelationshipUser
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return user?.call(id, attributes);
@@ -2707,7 +2707,7 @@ class _$RelationshipUser
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -2879,7 +2879,7 @@ class _$Artist with DiagnosticableTreeMixin implements Artist {
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -2894,7 +2894,7 @@ class _$Artist with DiagnosticableTreeMixin implements Artist {
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return artist?.call(id, attributes);
@@ -2908,7 +2908,7 @@ class _$Artist with DiagnosticableTreeMixin implements Artist {
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -3079,7 +3079,7 @@ class _$Author with DiagnosticableTreeMixin implements Author {
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -3094,7 +3094,7 @@ class _$Author with DiagnosticableTreeMixin implements Author {
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return author?.call(id, attributes);
@@ -3108,7 +3108,7 @@ class _$Author with DiagnosticableTreeMixin implements Author {
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -3266,7 +3266,7 @@ class _$RelationshipCreator
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -3281,7 +3281,7 @@ class _$RelationshipCreator
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return creator?.call(id);
@@ -3295,7 +3295,7 @@ class _$RelationshipCreator
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -3382,9 +3382,9 @@ abstract class _$$CoverArtCopyWith<$Res>
       __$$CoverArtCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String id, CoverArtAttributes attributes});
+  $Res call({String id, CoverArtAttributes? attributes});
 
-  $CoverArtAttributesCopyWith<$Res> get attributes;
+  $CoverArtAttributesCopyWith<$Res>? get attributes;
 }
 
 /// @nodoc
@@ -3398,24 +3398,28 @@ class __$$CoverArtCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = null,
-    Object? attributes = null,
+    Object? attributes = freezed,
   }) {
     return _then(_$CoverArt(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      attributes: null == attributes
+      attributes: freezed == attributes
           ? _value.attributes
           : attributes // ignore: cast_nullable_to_non_nullable
-              as CoverArtAttributes,
+              as CoverArtAttributes?,
     ));
   }
 
   @override
   @pragma('vm:prefer-inline')
-  $CoverArtAttributesCopyWith<$Res> get attributes {
-    return $CoverArtAttributesCopyWith<$Res>(_value.attributes, (value) {
+  $CoverArtAttributesCopyWith<$Res>? get attributes {
+    if (_value.attributes == null) {
+      return null;
+    }
+
+    return $CoverArtAttributesCopyWith<$Res>(_value.attributes!, (value) {
       return _then(_value.copyWith(attributes: value));
     });
   }
@@ -3434,7 +3438,7 @@ class _$CoverArt with DiagnosticableTreeMixin implements CoverArt {
   @override
   final String id;
   @override
-  final CoverArtAttributes attributes;
+  final CoverArtAttributes? attributes;
 
   @JsonKey(name: 'type')
   final String $type;
@@ -3467,7 +3471,7 @@ class _$CoverArt with DiagnosticableTreeMixin implements CoverArt {
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -3482,7 +3486,7 @@ class _$CoverArt with DiagnosticableTreeMixin implements CoverArt {
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return cover?.call(id, attributes);
@@ -3496,7 +3500,7 @@ class _$CoverArt with DiagnosticableTreeMixin implements CoverArt {
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {
@@ -3563,13 +3567,13 @@ class _$CoverArt with DiagnosticableTreeMixin implements CoverArt {
 abstract class CoverArt implements Relationship, Cover {
   const factory CoverArt(
       {required final String id,
-      required final CoverArtAttributes attributes}) = _$CoverArt;
+      required final CoverArtAttributes? attributes}) = _$CoverArt;
 
   factory CoverArt.fromJson(Map<String, dynamic> json) = _$CoverArt.fromJson;
 
   @override
   String get id;
-  CoverArtAttributes get attributes;
+  CoverArtAttributes? get attributes;
   @override
   @JsonKey(ignore: true)
   _$$CoverArtCopyWith<_$CoverArt> get copyWith =>
@@ -3672,7 +3676,7 @@ class _$ScanlationGroup
     required TResult Function(String id, AuthorAttributes attributes) artist,
     required TResult Function(String id, AuthorAttributes attributes) author,
     required TResult Function(String id) creator,
-    required TResult Function(String id, CoverArtAttributes attributes) cover,
+    required TResult Function(String id, CoverArtAttributes? attributes) cover,
     required TResult Function(String id, ScanlationGroupAttributes attributes)
         group,
   }) {
@@ -3687,7 +3691,7 @@ class _$ScanlationGroup
     TResult? Function(String id, AuthorAttributes attributes)? artist,
     TResult? Function(String id, AuthorAttributes attributes)? author,
     TResult? Function(String id)? creator,
-    TResult? Function(String id, CoverArtAttributes attributes)? cover,
+    TResult? Function(String id, CoverArtAttributes? attributes)? cover,
     TResult? Function(String id, ScanlationGroupAttributes attributes)? group,
   }) {
     return group?.call(id, attributes);
@@ -3701,7 +3705,7 @@ class _$ScanlationGroup
     TResult Function(String id, AuthorAttributes attributes)? artist,
     TResult Function(String id, AuthorAttributes attributes)? author,
     TResult Function(String id)? creator,
-    TResult Function(String id, CoverArtAttributes attributes)? cover,
+    TResult Function(String id, CoverArtAttributes? attributes)? cover,
     TResult Function(String id, ScanlationGroupAttributes attributes)? group,
     required TResult orElse(),
   }) {

--- a/lib/mangadex/types.freezed.dart
+++ b/lib/mangadex/types.freezed.dart
@@ -6935,9 +6935,10 @@ class __$$_SelfRatingCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_SelfRating with DiagnosticableTreeMixin implements _SelfRating {
+class _$_SelfRating extends _SelfRating with DiagnosticableTreeMixin {
   _$_SelfRating(
-      {required this.rating, @TimestampSerializer() required this.createdAt});
+      {required this.rating, @TimestampSerializer() required this.createdAt})
+      : super._();
 
   factory _$_SelfRating.fromJson(Map<String, dynamic> json) =>
       _$$_SelfRatingFromJson(json);
@@ -6990,11 +6991,12 @@ class _$_SelfRating with DiagnosticableTreeMixin implements _SelfRating {
   }
 }
 
-abstract class _SelfRating implements SelfRating {
+abstract class _SelfRating extends SelfRating {
   factory _SelfRating(
           {required final int rating,
           @TimestampSerializer() required final DateTime createdAt}) =
       _$_SelfRating;
+  _SelfRating._() : super._();
 
   factory _SelfRating.fromJson(Map<String, dynamic> json) =
       _$_SelfRating.fromJson;

--- a/lib/mangadex/types.g.dart
+++ b/lib/mangadex/types.g.dart
@@ -282,8 +282,10 @@ Map<String, dynamic> _$$RelationshipCreatorToJson(
 
 _$CoverArt _$$CoverArtFromJson(Map<String, dynamic> json) => _$CoverArt(
       id: json['id'] as String,
-      attributes: CoverArtAttributes.fromJson(
-          json['attributes'] as Map<String, dynamic>),
+      attributes: json['attributes'] == null
+          ? null
+          : CoverArtAttributes.fromJson(
+              json['attributes'] as Map<String, dynamic>),
       $type: json['type'] as String?,
     );
 

--- a/lib/mangadex/widgets.dart
+++ b/lib/mangadex/widgets.dart
@@ -66,7 +66,8 @@ class ChapterFeedWidget extends HookConsumerWidget {
         AsyncValue(:final error?, :final stackTrace?) => () {
             final messenger = ScaffoldMessenger.of(context);
             Styles.showErrorSnackBar(messenger, '$error');
-            logger.e("${provider.toString()} failed", error, stackTrace);
+            logger.e("${provider.toString()} failed",
+                error: error, stackTrace: stackTrace);
 
             return RefreshIndicator(
               onRefresh: onRefresh,
@@ -144,7 +145,8 @@ class ChapterFeedItem extends ConsumerWidget {
         AsyncValue(:final error?, :final stackTrace?) => () {
             final messenger = ScaffoldMessenger.of(context);
             Styles.showErrorSnackBar(messenger, '$error');
-            logger.e("readChaptersProvider failed", error, stackTrace);
+            logger.e("readChaptersProvider failed",
+                error: error, stackTrace: stackTrace);
 
             return null;
           }(),

--- a/lib/reader/config.g.dart
+++ b/lib/reader/config.g.dart
@@ -52,4 +52,5 @@ final readerSettingsProvider =
 );
 
 typedef _$ReaderSettings = AutoDisposeNotifier<ReaderConfig>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -21,13 +21,10 @@ extension StringExtension on String {
 }
 
 class DeviceContext {
-  static bool isMobile() {
-    return (Platform.isIOS || Platform.isAndroid);
-  }
+  static bool isMobile() => (Platform.isIOS || Platform.isAndroid);
 
-  static bool isDesktop() {
-    return (Platform.isLinux || Platform.isWindows || Platform.isMacOS);
-  }
+  static bool isDesktop() =>
+      (Platform.isLinux || Platform.isWindows || Platform.isMacOS);
 
   static bool screenWidthSmall(BuildContext context) {
     // Somewhat arbitrary measurement but w/e

--- a/lib/web/model.dart
+++ b/lib/web/model.dart
@@ -10,7 +10,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'model.g.dart';
 
-final proxyProvider = Provider(ProxyHandler.new);
+@Riverpod(keepAlive: true)
+ProxyHandler proxy(ProxyRef ref) {
+  return ProxyHandler(ref);
+}
 
 class ProxyHandler {
   ProxyHandler(this.ref);

--- a/lib/web/model.g.dart
+++ b/lib/web/model.g.dart
@@ -6,6 +6,20 @@ part of 'model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$proxyHash() => r'9c1283bf072913b04bc06342dad4b6ff01fd1e7e';
+
+/// See also [proxy].
+@ProviderFor(proxy)
+final proxyProvider = Provider<ProxyHandler>.internal(
+  proxy,
+  name: r'proxyProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$proxyHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ProxyRef = ProviderRef<ProxyHandler>;
 String _$webSourceHistoryHash() => r'6ee2202cbc821ae1463075d7e85ffb8f03e3091a';
 
 /// See also [WebSourceHistory].

--- a/lib/web/model.g.dart
+++ b/lib/web/model.g.dart
@@ -36,4 +36,5 @@ final webSourceHistoryProvider =
 );
 
 typedef _$WebSourceHistory = AsyncNotifier<Queue<HistoryLink>>;
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/lib/web/reader.dart
+++ b/lib/web/reader.dart
@@ -73,7 +73,8 @@ class WebSourceReaderWidget extends ConsumerWidget {
       case AsyncValue(:final error?, :final stackTrace?):
         final messenger = ScaffoldMessenger.of(context);
         Styles.showErrorSnackBar(messenger, '$error');
-        logger.e("_getPagesProvider($source) failed", error, stackTrace);
+        logger.e("_getPagesProvider($source) failed",
+            error: error, stackTrace: stackTrace);
 
         return Scaffold(
           appBar: AppBar(

--- a/lib/web/reader.g.dart
+++ b/lib/web/reader.g.dart
@@ -108,4 +108,5 @@ class _GetPagesProvider extends AutoDisposeFutureProvider<List<ReaderPage>> {
     return _SystemHash.finish(hash);
   }
 }
-// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,10 +314,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: b10cab7e0e4dbb60ff5360a740def3919aecbc672240f742a7130a2874204229
+      sha256: "9eab8fd7aa752c3c1c0a364f9825851d410eb935243411682f4b1b0a4c569d71"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -443,12 +443,11 @@ packages:
   hooks_riverpod:
     dependency: "direct main"
     description:
-      path: "packages/hooks_riverpod"
-      ref: HEAD
-      resolved-ref: a6900e01cde9ac2a408dd5590c67eecc9d8511c0
-      url: "https://github.com/rrousselGit/riverpod"
-    source: git
-    version: "2.3.6"
+      name: hooks_riverpod
+      sha256: "117edbe7e5cfc02e31a94f97e2acd4581f54bc37fcda9dce1f606f8ac851ba24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.7"
   hotreloader:
     dependency: transitive
     description:
@@ -557,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "7ad7215c15420a102ec687bb320a7312afd449bac63bfb1c60d9787c27b9767f"
+      sha256: "496066067d1990c654cdf8cbbb35936e39105d90e8579495cd1daa506cded2e7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
@@ -797,18 +796,18 @@ packages:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: cd0595de57ccf5d944ff4b0f68289e11ac6a2eff1e3dfd1d884a43f6f3bcee5e
+      sha256: "691180275664a5420c87d72c1ed26ef8404d32b823807540172bfd1660425376"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "043ff016011be4c5887b3239bfbca05d284bdb68db0a5363cee0242b7567e250"
+      sha256: "17ad319914ac6863c64524e598913c0f17e30688aca8f5b7509e96d6e372d493"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   rxdart:
     dependency: transitive
     description:
@@ -1090,10 +1089,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: dfdf0136e0aa7a1b474ea133e67cb0154a0acd2599c4f3ada3b49d38d38793ee
+      sha256: f2add6fa510d3ae152903412227bda57d0d5a8da61d2c39c1fb022c9429a41c0
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.5"
+    version: "5.0.6"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -285,18 +285,18 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   file_picker:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: b1729fc96627dd44012d0a901558177418818d6bd428df59dcfeb594e5f66432
+      sha256: "21145c9c268d54b1f771d8380c195d2d6f655e0567dc1ca2f9c134c02c819e0a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "5.3.3"
   fixnum:
     dependency: transitive
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: "6a126f703b89499818d73305e4ce1e3de33b4ae1c5512e3b8eab4b986f46774c"
+      sha256: b10cab7e0e4dbb60ff5360a740def3919aecbc672240f742a7130a2874204229
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.6"
+    version: "0.19.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -443,10 +443,11 @@ packages:
   hooks_riverpod:
     dependency: "direct main"
     description:
-      name: hooks_riverpod
-      sha256: be68cf7653fcab798500f9047ac58c3f109287a1595012412f4a0d654a9bb9c5
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/hooks_riverpod"
+      ref: HEAD
+      resolved-ref: a6900e01cde9ac2a408dd5590c67eecc9d8511c0
+      url: "https://github.com/rrousselGit/riverpod"
+    source: git
     version: "2.3.6"
   hotreloader:
     dependency: transitive
@@ -572,10 +573,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "8e332924094383133cee218b676871f42db2514f1f6ac617b6cf6152a7faab8e"
+      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.1.1"
   matcher:
     dependency: transitive
     description:
@@ -676,10 +677,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "1995d88ec2948dac43edf8fe58eb434d35d22a2940ecee1a9fefcd62beee6eb3"
+      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   path_provider_linux:
     dependency: transitive
     description:
@@ -732,10 +733,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pointycastle:
     dependency: transitive
     description:
@@ -752,14 +753,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -977,10 +970,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "15f5acbf0dce90146a0f5a2c4a002b1814a6303c4c5c075aa2623b2d16156f03"
+      sha256: "78cb6dea3e93148615109e58e42c35d1ffbf5ef66c44add673d0ab75f12ff3af"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.36"
+    version: "6.0.37"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1001,10 +994,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
+      sha256: "1c4fdc0bfea61a70792ce97157e5cc17260f61abbe4f39354513f39ec6fd73b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1073,10 +1066,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b8c67f5fa3897b122cf60fe9ff314f7b0ef71eab25c5f8b771480bc338f48823
+      sha256: ada49637c27973c183dad90beb6bd781eea4c9f5f955d35da172de0af7bd3440
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.2"
+    version: "11.8.0"
   watcher:
     dependency: transitive
     description:
@@ -1105,10 +1098,10 @@ packages:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      sha256: e0b1147eec179d3911f1f19b59206448f78195ca1d20514134e10641b7d7fbff
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   xml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -556,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: "496066067d1990c654cdf8cbbb35936e39105d90e8579495cd1daa506cded2e7"
+      sha256: "66cb048220ca51cf9011da69fa581e4ee2bed4be6e82870d9e9baae75739da49"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,12 +36,15 @@ dependencies:
   file_picker: ^5.3.0
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.18.6
+  flutter_hooks: ^0.19.0
   flutter_markdown: ^0.6.16
   freezed_annotation: ^2.2.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  hooks_riverpod: ^2.3.5
+  hooks_riverpod:
+    git:
+      url: https://github.com/rrousselGit/riverpod
+      path: packages/hooks_riverpod
   http: ^1.0.0
   json_annotation: ^4.8.1
   # openid_client: ^0.4.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,19 +36,16 @@ dependencies:
   file_picker: ^5.3.0
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.19.0
+  flutter_hooks: ^0.20.0
   flutter_markdown: ^0.6.16
   freezed_annotation: ^2.2.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  hooks_riverpod:
-    git:
-      url: https://github.com/rrousselGit/riverpod
-      path: packages/hooks_riverpod
+  hooks_riverpod: ^2.3.7
   http: ^1.0.0
   json_annotation: ^4.8.1
   # openid_client: ^0.4.7
-  logger: ^1.4.0
+  logger: ^2.0.0
   mutex: ^3.0.1
   package_info_plus: ^4.0.2
   path: ^1.8.3
@@ -70,7 +67,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   custom_lint: ^0.4.0
-  riverpod_lint: ^1.3.2
+  riverpod_lint: ^1.4.0
   build_runner:
   riverpod_generator: ^2.2.3
   freezed: ^2.3.2


### PR DESCRIPTION
- Fixed a bug where user library view does not paginate when the content rating filter setting filters out at least one item
- Fixed handling a case where a manga may have an (unwarranted) empty/null cover art field
- Fixed AuthControl not invalidating/rebuilding on resume on Android while app is paused in the background
- Expire certain user data types that should be refreshed every so often, especially when accessing MD from multiple devices (read chapters, rating, reading/following status)
- Fixed user library not updating when a manga's reading status is changed
- Switch to Material 3 styled navigation bar and drawer
- Updated dependencies